### PR TITLE
로그아웃 API

### DIFF
--- a/src/main/java/com/fc/fcseoularchive/domain/auth/AuthController.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/AuthController.java
@@ -63,4 +63,15 @@ public class AuthController {
             throw new ApiException(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "401", "잘못된 JWT 입니다." );
         }
     }
+
+    @Operation(summary = "로그아웃 API, 헤더로 AccessToken")
+    @GetMapping("/logout")
+    public ResponseEntity<String> logout(@RequestHeader("Authorization") String bearerToken){
+        String accessToken = bearerToken.replace("Bearer ", "");
+        String userId = parseUserIdFromExpiredJwt(accessToken);
+        String logoutUrl = authService.logout(accessToken, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(logoutUrl);
+    }
+
+
 }

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/AuthController.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/AuthController.java
@@ -8,7 +8,6 @@ import com.fc.fcseoularchive.domain.auth.dto.TokenResponse;
 import com.fc.fcseoularchive.global.error.ApiException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +26,7 @@ public class AuthController {
     // 프론트 Callback.tsx에서 호출
     @Operation(summary = "콜백 API , 프론트 -> 서버로 인가코드, Verifier 보내주면 AccessToken 발급")
     @PostMapping("/callback")
-    public ResponseEntity<AccessTokenResponse> callback(@RequestBody CallbackRequest request, HttpServletResponse response) {
+    public ResponseEntity<AccessTokenResponse> callback(@RequestBody CallbackRequest request) {
         TokenResponse token = authService.exchangeCodeForToken(
                 request.getCode(),
                 request.getCodeVerifier()
@@ -64,14 +63,13 @@ public class AuthController {
         }
     }
 
-    @Operation(summary = "로그아웃 API, 헤더로 AccessToken")
+    @Operation(summary = "로그아웃 API, 헤더로 AccessToken, 401 에러 시 프론트에서 로그아웃 처리")
     @GetMapping("/logout")
     public ResponseEntity<String> logout(@RequestHeader("Authorization") String bearerToken){
         String accessToken = bearerToken.replace("Bearer ", "");
         String userId = parseUserIdFromExpiredJwt(accessToken);
-        String logoutUrl = authService.logout(accessToken, userId);
+        String logoutUrl = authService.logout(userId);
         return ResponseEntity.status(HttpStatus.OK).body(logoutUrl);
     }
-
 
 }

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/AuthService.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/AuthService.java
@@ -120,7 +120,7 @@ public class AuthService {
     }
 
     // 로그아웃 처리
-    public String logout(String accessToken, String userId) {
+    public String logout(String userId) {
 
         // 캐시에서 리프레시 토큰 가져오기
         TokenValues tokenValues = tokenCacheService.getRefreshToken(userId);

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/AuthService.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/AuthService.java
@@ -4,6 +4,7 @@ package com.fc.fcseoularchive.domain.auth;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fc.fcseoularchive.domain.auth.dto.TokenResponse;
+import com.fc.fcseoularchive.domain.auth.dto.TokenValues;
 import com.fc.fcseoularchive.global.error.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
@@ -21,11 +24,22 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthService {
 
-    @Value("${keycloak.url}") private String keycloakUrl;
-    @Value("${keycloak.realm}") private String realm;
-    @Value("${keycloak.client-id}") private String clientId;
-    @Value("${keycloak.client-secret}") private String clientSecret;
-    @Value("${frontend.redirect-uri}") private String redirectUri;
+    @Value("${keycloak.url}")
+    private String keycloakUrl;
+    @Value("${keycloak.logout-uri}")
+    private String keycloakLogoutUri;
+    @Value("${keycloak.realm}")
+    private String realm;
+    @Value("${keycloak.client-id}")
+    private String clientId;
+    @Value("${keycloak.client-secret}")
+    private String clientSecret;
+
+
+    @Value("${frontend.redirect-uri}")
+    private String redirectUri;
+    @Value("${frontend.redirect-uri-logout}")
+    private String redirectUriLogout;
 
     private final TokenCacheService tokenCacheService; // 스프링 캐시 쓰기
     private final RestClient restClient = RestClient.create(); // Keyclaok과 통신하기 위함
@@ -38,12 +52,13 @@ public class AuthService {
     // 프론트에서 들어온 인가 코드 , codeVerifier 로 AccessToken, RefreshToken 발급 받기!
     public TokenResponse exchangeCodeForToken(String code, String codeVerifier) {
         TokenResponse token = requestToken(Map.of(
-                "grant_type",    "authorization_code",
-                "client_id",     clientId,
+                "grant_type", "authorization_code",
+                "client_id", clientId,
                 "client_secret", clientSecret,
-                "redirect_uri",  redirectUri,
-                "code",          code,
-                "code_verifier", codeVerifier
+                "redirect_uri", redirectUri,
+                "code", code,
+                "code_verifier", codeVerifier,
+                "scope", "openid profile email" // Keycloak 은 요청에 openid 라는 스코프를 명시해야 OIDC사용을 판단가능
         ));
         saveRefreshToken(token);
         return token;
@@ -51,16 +66,17 @@ public class AuthService {
 
     // 리프레시 토큰 반환하기
     public TokenResponse refreshToken(String userId) {
-        String savedRefreshToken = tokenCacheService.getRefreshToken(userId);
-        if (savedRefreshToken == null) {
-            throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "500","리프레시 토큰을 찾을 수 없습니다.. 다시 로그인 해 주세요." );
+        TokenValues tokenValues = tokenCacheService.getRefreshToken(userId);
+        if (tokenValues.getRefreshToken() == null) {
+            throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "500", "리프레시 토큰을 찾을 수 없습니다. 다시 로그인 해 주세요.");
         }
 
         TokenResponse token = requestToken(Map.of(
-                "grant_type",    "refresh_token",
-                "client_id",     clientId,
+                "grant_type", "refresh_token",
+                "client_id", clientId,
                 "client_secret", clientSecret,
-                "refresh_token", savedRefreshToken
+                "refresh_token", tokenValues.getRefreshToken(),
+                "id_token", tokenValues.getIdToken()
         ));
 
         saveRefreshToken(token);
@@ -70,7 +86,8 @@ public class AuthService {
     // 리프레시 토큰 저장하기
     private void saveRefreshToken(TokenResponse token) {
         String userId = parseUserIdFromJwt(token.getAccessToken());
-        tokenCacheService.saveRefreshToken(userId, token.getRefreshToken());
+        TokenValues tokenValues = new TokenValues(token.getRefreshToken(), token.getIdToken());
+        tokenCacheService.saveRefreshToken(userId, tokenValues);
     }
 
     // param 으로 들어온 정보를 통해 토큰 POST 해서 발급 받기
@@ -98,8 +115,50 @@ public class AuthService {
             JsonNode node = mapper.readTree(decoded);
             return node.get("sub").asText();
         } catch (Exception e) {
-            throw new ApiException(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "401", "잘못된 JWT 입니다." );
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "401", "잘못된 JWT 입니다.");
         }
     }
 
+    // 로그아웃 처리
+    public String logout(String accessToken, String userId) {
+
+        // 캐시에서 리프레시 토큰 가져오기
+        TokenValues tokenValues = tokenCacheService.getRefreshToken(userId);
+
+        // 캐시에서 리프레시 토큰 지워주기
+        tokenCacheService.removeRefreshToken(userId);
+
+        /**
+         * MultiValueMap 사용 이유?
+         * RestClient는 Map 을 받으면 기본 메시지 컨버터로 처리를함.
+         * 하지만 APPLICATION_FORM_URLENCODED 는 MultiValueMap 을 요구함
+         * 즉, Map 을 넘기면 Jackson이 JSON 으로 직렬화해서 보내면서 400 에러를 발생시킴
+         */
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("refresh_token", tokenValues.getRefreshToken());
+
+        // 키클락에 로그아웃요청하기
+        RestClient.create(keycloakUrl)
+                .post()
+                .uri(keycloakLogoutUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .toBodilessEntity();
+
+        // 프론트가 리다이렉트할 URL 만들기
+        // idToken 관리가 필요함
+        String logoutUrl = String.format(
+                "%s/realms/%s/protocol/openid-connect/logout" +
+                        "?id_token_hint=%s&post_logout_redirect_uri=%s",
+                keycloakUrl,
+                realm,
+                tokenValues.getIdToken(),
+                URLEncoder.encode(redirectUriLogout, StandardCharsets.UTF_8)
+        );
+
+        return logoutUrl;
+    }
 }

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/TokenCacheService.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/TokenCacheService.java
@@ -1,26 +1,49 @@
 package com.fc.fcseoularchive.domain.auth;
 
+import com.fc.fcseoularchive.domain.auth.dto.TokenValues;
+import lombok.extern.slf4j.Slf4j;
+import org.antlr.v4.runtime.Token;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+
+@Slf4j
 @Service
 @CacheConfig(cacheNames = "refreshTokens")
 public class TokenCacheService {
 
+    /**
+     * TokenValues
+     *      .refreshToken
+     *      .idToken : 로그인 시 발급되는 id_token -> 로그 아웃 시 필요함
+     *
+     * Put : 저장
+     * able : 가져오기
+     * Evict : 삭제
+     */
     @CachePut(key = "#userId")
-    public String saveRefreshToken(String userId, String refreshToken) {
+    public TokenValues saveRefreshToken(String userId, TokenValues tokenValues) {
 
-        System.out.println("✅ 캐시 저장 - userId: " + userId); // 캐시 디버깅 용도
-        System.out.println("✅ 캐시 저장 - refreshToken: " + refreshToken);
-        return refreshToken;
+        log.info("캐시 저장 - userId: {}", userId);
+        log.info("캐시 저장 - refreshToken: {}", tokenValues.getRefreshToken());
+        log.info("캐시 저장 - idToken: {}", tokenValues.getIdToken());
+
+        return tokenValues;
     }
 
     @Cacheable(key = "#userId")
-    public String getRefreshToken(String userId) {
+    public TokenValues getRefreshToken(String userId) {
         return null;  // 캐시 미스 시 null 반환
     }
+
+    @CacheEvict(key = "#userId")
+    public TokenValues removeRefreshToken(String userId) {
+        return null;
+    }
+
+
 
 }

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/dto/TokenResponse.java
@@ -16,4 +16,7 @@ public class TokenResponse {
     @JsonProperty("refresh_token")
     private String refreshToken;
 
+    @JsonProperty("id_token")
+    private String idToken; // 로그아웃시 필요한 idToken
+
 }

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/dto/TokenValues.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/dto/TokenValues.java
@@ -1,0 +1,22 @@
+package com.fc.fcseoularchive.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+/**
+ * 캐시 value 에 들어가는 타입
+ *
+ * 기존 String[] 으로 만들어놨지만 가독성이 너무 떨어져서 만듦
+ */
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class TokenValues {
+
+    String refreshToken;
+    String idToken;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,10 +78,13 @@ keycloak:
   realm: fcraichu
   client-id: react
   client-secret: kAykNzrjgNyRR3tPtCoTmzthOAAGlQhh
+  logout-uri: /realms/fcraichu/protocol/openid-connect/logout
+
 
 
 frontend:
   redirect-uri: http://localhost:5173/login
+  redirect-uri-logout: http://localhost:5173/
 
 
 # 시크릿 키는 : https://jwtsecretkeygenerator.com/ko/ 여기서 만듦

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ keycloak:
   realm: fcraichu
   client-id: react
   client-secret: j8VzAEJ8PPXi5Wjt4rEwweU95lkRZbvW
+  logout-uri: /realms/fcraichu/protocol/openid-connect/logout
 
 
 frontend:


### PR DESCRIPTION
기존 : 프론트에서 토큰만 지워주기
문제점 : 재 로그인시 키클락에 세션이 살아있어서 완전한 로그아웃 x

변경 : 로그아웃 API 만들기
변경점 : 키클락에 세션을 지워주며 완전한 로그아웃 처리

- [x] 로그아웃 API 만들기
- [x] DTO 처리
        -> tokenValues 처리
- [x] 예외 처리
        -> 예외처리는 토큰 잘못된 것으로 충분 프론트에서 그 후 처리 방식

---
1. id_token 필요
-> access_token 발급시 id_token 같이 받아오도록 변경

2. id_token 을 저장하고 있어야함
-> 왜?  로그아웃 처리시 id_token 을 같이 보내줘야함. (keycloak 이 그렇게 만들어졌음)

3. id_token 을 발급받기 위해 로그인 시 socpe 추가
-> accessToken 발급 시 스코프에 openid profile email 추가함으로 OIDC 사용한다고 처리

4. id_token 받아온 것 refreshToken 과 함께 캐시에 저장
-> 기존 <String, String> : <userId, refreshToken> 에서
<String, String[]> 로 변경하기 -> <userId, String[0]: refreshToken, String[1]: idToken>

---

Closes #70 