### PR TITLE
#72 fix: 시큐리티 필터 우회를 위한 리프레시 전용 커스텀 헤더 적용

### DIFF
--- a/src/main/java/com/fc/fcseoularchive/config/SecurityConfig.java
+++ b/src/main/java/com/fc/fcseoularchive/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.fc.fcseoularchive.config;
 
+import com.fc.fcseoularchive.global.error.ApiException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.core.convert.converter.Converter;
 import lombok.RequiredArgsConstructor;
@@ -103,7 +106,27 @@ public class SecurityConfig {
         /** OAuth2 리소스 서버 설정 및 토큰에서 ROLE 꺼내오기 */
         httpSecurity
                 .oauth2ResourceServer(oauth2 -> oauth2
-                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)));
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
+                        .authenticationEntryPoint(((request, response, authException) -> {
+                                    if (request.getRequestURI().startsWith("/api/auth/refresh")) {
+                                        /**
+                                         * setStatus, forward 둘 다 사용 x
+                                         * 바로 컨트롤러로 넘어 갈 수 있게끔.
+                                         */
+                                        return ;
+                                    } else {
+                                        /**
+                                         * RestControllerAdvice는 Spring MVC 영역에서 동작하지만!
+                                         * Spring Security 는 MVC 보다 더 앞단에서 동작하기 때문에
+                                         * response.sendError 를 사용해야함.
+                                         */
+                                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+                                    }
+                                })
+
+
+                        )
+                );
 
 
         return httpSecurity.build();
@@ -149,15 +172,15 @@ public class SecurityConfig {
 
             List<String> roles = jwt.getClaimAsStringList("role");
 
-            if(roles == null){
+            if (roles == null) {
                 return authorities;
             }
 
-            if(roles.contains("ADMIN")){
+            if (roles.contains("ADMIN")) {
                 authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
             }
 
-            if(roles.contains("USER")) {
+            if (roles.contains("USER")) {
                 authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
             }
 

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/AuthController.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/AuthController.java
@@ -38,13 +38,15 @@ public class AuthController {
     // 프론트 인터셉터에서 401 시 자동 호출
     @Operation(summary = "refreshToken API AccessToken 만 헤더로 보내주면 됨")
     @PostMapping("/refresh")
-    public ResponseEntity<AccessTokenResponse> refresh(@RequestHeader("Authorization") String bearerToken) {
+    public ResponseEntity<AccessTokenResponse> refresh(@RequestHeader("X-Expired-AccessToken") String bearerToken) {
 
         // 만료된 access_token에서 userId 추출
         String expiredToken = bearerToken.replace("Bearer ", "");
         String userId = parseUserIdFromExpiredJwt(expiredToken);
 
         TokenResponse token = authService.refreshToken(userId);
+
+        System.out.println("발급된 토큰: " + token.getAccessToken());
 
         return ResponseEntity.status(HttpStatus.OK).body(new AccessTokenResponse(token.getAccessToken()));
     }
@@ -57,7 +59,7 @@ public class AuthController {
         String decoded = new String(Base64.getUrlDecoder().decode(payload));
         try {
             JsonNode node = new ObjectMapper().readTree(decoded);
-            return node.get("sub").asText();
+            return node.get("id").asText();
         } catch (Exception e) {
             throw new ApiException(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "401", "잘못된 JWT 입니다." );
         }

--- a/src/main/java/com/fc/fcseoularchive/domain/auth/AuthService.java
+++ b/src/main/java/com/fc/fcseoularchive/domain/auth/AuthService.java
@@ -80,6 +80,7 @@ public class AuthService {
         ));
 
         saveRefreshToken(token);
+
         return token;
     }
 
@@ -107,7 +108,7 @@ public class AuthService {
 
     // jwt 에서 유저의 id 파싱 하기
     // ex) "sub": "dae19fe0-e5e7-43ac-a492-e1eb395c2662" // 키클락에서 uuid 로 저장함
-    private String parseUserIdFromJwt(String jwt) {
+    public String parseUserIdFromJwt(String jwt) {
         String payload = jwt.split("\\.")[1];
         String decoded = new String(Base64.getUrlDecoder().decode(payload));
         try {

--- a/src/test/java/com/fc/fcseoularchive/inwooTest/RefreshJwtTest.java
+++ b/src/test/java/com/fc/fcseoularchive/inwooTest/RefreshJwtTest.java
@@ -1,0 +1,30 @@
+package com.fc.fcseoularchive.inwooTest;
+
+import com.fc.fcseoularchive.domain.auth.AuthService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class RefreshJwtTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Test
+    @DisplayName("만료된 jwt 에서 userId 만 뽑아오기")
+    public void test1() throws Exception{
+    
+        String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJiU0pBR0wzd2NDWTI5RzR6bG5rUHhWYlFXb25fbDNXekx5bks2eVQzVU0wIn0.eyJleHAiOjE3NzcxOTE4ODcsImlhdCI6MTc3NzE5MTgyNywiYXV0aF90aW1lIjoxNzc3MTkxODI2LCJqdGkiOiJvbnJ0YWM6ODM4NzRlMDUtMTJlMS1jNzNiLWU5MDgtNTljMmUwNTJmMWZiIiwiaXNzIjoiaHR0cHM6Ly9mY3JhaWNodS5pbndvb2h1Yi5jb20vYXV0aC9yZWFsbXMvZmNyYWljaHUiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiNjAxYmYwZjktZjk1Mi00MTg4LTkwZTYtNzhhNWU2NDcwZGE3IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoicmVhY3QiLCJzaWQiOiJvcUlsYU9IaUMxMjJIZm81aW1RUl9pUEwiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbIioiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImRlZmF1bHQtcm9sZXMtZmNyYWljaHUiLCJBRE1JTiIsIlVTRVIiXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJyb2xlIjpbImRlZmF1bHQtcm9sZXMtZmNyYWljaHUiLCJBRE1JTiIsIlVTRVIiXSwicHJlZmVycmVkX3VzZXJuYW1lIjoiZGxzZG5kbHNAbmF2ZXIuY29tIiwiaWQiOiI2MDFiZjBmOS1mOTUyLTQxODgtOTBlNi03OGE1ZTY0NzBkYTciLCJsb2NhbGUiOiJrbyIsImVtYWlsIjoiZGxzZG5kbHNAbmF2ZXIuY29tIn0.Rmjkx-dUiG2lDrehER_ewwnb0eLeN5AWQSydwQN_13S0LjAm9I0Bk9efwf4EJrqBOe8oSaFy22uU5i-KlzBEMVlOH_OYg4b3Q9_BagJPLYDrgbScxjWknwgJw85r-RzKJUZbNyYZMDXHNXqEi5euBNXTla0KORflZaolpKjC1N4VmXHVHR51J-iOLD0-ePTrvz5K7H3E_YHLsjwVLPpgizwRiV4xJsxvOZ1Uxytu3dv20rKHVxpWzzDyx6tP63-J9J4FyUHVpVyM9q5hh_tj631IO1KTi0y9Az-JLHj8pMUB2IJTQjvMnb60fIeGNeoZo3mD6WWEPs6ssCI3jsl3PA";
+
+        String userId = authService.parseUserIdFromJwt(jwt);
+
+        System.out.println("userId = " + userId);
+
+
+
+    }
+
+
+}

--- a/src/test/java/com/fc/fcseoularchive/inwooTest/jwtTest2.java
+++ b/src/test/java/com/fc/fcseoularchive/inwooTest/jwtTest2.java
@@ -1,13 +1,10 @@
 package com.fc.fcseoularchive.inwooTest;
 
-import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashSet;
 
 @SpringBootTest
 public class jwtTest2 {


### PR DESCRIPTION
- [x] 리프레시 토큰은 만료되어도 id라는 claim 에서 꺼내기도전에 401 Error 발생

Closes #72 

---
문제 상황: 만료된 토큰을 Authorization 헤더로 보낼 시, Spring Security 필터가 컨트롤러 도달 전 401 에러로 요청을 선제 차단하는 현상 발생.

해결 방법: 시큐리티 필터의 간섭을 피하기 위해 커스텀 헤더(X-Expired-AccessToken)를 도입하여 인증 검증 과정을 우회하고 컨트롤러 진입 허용

구현 결과: /api/auth/refresh 경로를 통해 보안 필터의 영향 없이 만료된 토큰에서 userId를 추출하고, 신규 토큰을 정상 발급 및 반환하도록 완성